### PR TITLE
Use @ operator to access variable within template

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -12,7 +12,7 @@ class openssh::config {
   $override)
 
   # build an array from the config-hash for the augeas resource
-  $separated_config = inline_template('<% merged_config.each do
+  $separated_config = inline_template('<% @merged_config.each do
   |name_and_options| -%>set <%= name_and_options[0] %> "<%= name_and_options[1]
   %>",<% end -%>')
   $config_array = split( chop( $separated_config ), ',')


### PR DESCRIPTION
Without the @ operator, puppet agent throws the following
error message (we use puppet version 4.3.0):
Error 400 on SERVER: Evaluation Error: Error while evaluating a
Function Call, Failed to parse inline template: undefined local
variable or method `merged_config'
